### PR TITLE
cancel request after timeout occurs, set a sensible timeout

### DIFF
--- a/pkg/client/forwarder.go
+++ b/pkg/client/forwarder.go
@@ -53,8 +53,8 @@ func (d *dropforwarder) writeTo(r io.ReadCloser) {
 			Timestamp: &timestamp.Timestamp{Seconds: cr.ts},
 			Fields:    fields,
 		}
-		// FIXME we leak cancel func here, dunno howto handle that.
-		ctx, _ := context.WithTimeout(context.TODO(), 35*time.Second)
+		ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+		defer cancel()
 		_, err = d.dsc.Push(
 			ctx,
 			de,


### PR DESCRIPTION
This was long overdue, untested.

Test needs to be done if a restart of the server components brings the connection back into work with this.